### PR TITLE
As discussed: patches to pkg-config

### DIFF
--- a/pkg-config
+++ b/pkg-config
@@ -113,6 +113,17 @@ GetOptions(	'debug' 		=> \$mode{debug},
 		'define-variable=s' 	=> $variables,
 	);
 
+# If --errors-to-stdout was given, close STDERR (to be safe),
+# then dup the output to STDOUT and delete the key from %mode so we
+# won't keep checking it. STDERR stays dup'ed.
+# We do this early so any other warnings also get redirected, since
+# they might indicate a bug that a regression test should catch.
+if ($mode{estdout}) {
+	close(STDERR);
+	open(STDERR, ">&STDOUT") or die "Can't dup STDOUT: $!";
+	delete($mode{estdout});
+}
+
 # Unconditionally switch to static mode on static arches as --static
 # may not have been passed explicitly, but we don't want to re-order
 # and simplify the libs like we do for shared architectures.
@@ -820,15 +831,6 @@ sub say_warning
 sub say_msg
 {
 	my $str = shift;
-
-	# If --errors-to-stdout was given, close STDERR (to be safe),
-	# then dup the output to STDOUT and delete the key from %mode so we
-	# won't keep checking it. STDERR stays dup'ed.
-	if ($mode{estdout}) {
-		close(STDERR);
-		open(STDERR, ">&STDOUT") or die "Can't dup STDOUT: $!";
-		delete($mode{estdout});
-	}
 
 	print STDERR $str . "\n";
 }

--- a/pkg-config
+++ b/pkg-config
@@ -48,6 +48,10 @@ my $found_uninstalled = 0;
 
 my $version = '0.27.1'; # pretend to be this version of pkgconfig
 
+# Regexp that captures our idea of a version number which accomodates
+# version numbers found in practice in e.g. the ports tree:
+my $vers_regexp = qr/^([\d\.]+)(|(-stable|rc|beta|alpha|[a-zA-Z])(|\d+))*$/;
+
 my %configs = ();
 setup_self();
 
@@ -166,7 +170,7 @@ while (@ARGV){
 	my $op = undef;
 	my $v = undef;
 	if (@ARGV >= 2  && $ARGV[0] =~ /^[<=>!]+$/ &&
-	    $ARGV[1] =~ /^[\d\.]+[\w\.]*$/) {
+	    $ARGV[1] =~ $vers_regexp) {
 	    	$op = shift @ARGV;
 		$v = shift @ARGV;
 	}
@@ -623,30 +627,23 @@ sub compare
 	return 0 if ($a eq $b);
 
 	# is there a valid non-numeric suffix to deal with later?
-	# accepted are (in order): a(lpha) < b(eta) < rc < ' '.
+	# accepted are listed in $vers_regexp, above, and are compared
+	# in alphabetical order, so e.g. 'beta' beats 'alpha'.
 	# suffix[0] is the 'alpha' part, suffix[1] is the '1' part in 'alpha1'.
-	if ($a =~ s/(rc|beta|b|alpha|a)(\d+)$//) {
-		say_debug("valid suffix $1$2 found in $a$1$2.");
-		$suffix_a[0] = $1;
-		$suffix_a[1] = $2;
+	# $2 will be the optional separator (currently nothing or dash)
+	if ($a =~ $vers_regexp && ($3 || $4)) {
+		$a = $1;
+		say_debug("valid suffix $3$4 found in $a$3$4");
+		$suffix_a[0] = $3;
+		$suffix_a[0] =~ s/^-//;
+		$suffix_a[1] = $4 || 0;
 	}
-
-	if ($b =~ s/(rc|beta|b|alpha|a)(\d+)$//) {
-		say_debug("valid suffix $1$2 found in $b$1$2.");
-		$suffix_b[0] = $1;
-		$suffix_b[1] = $2;
-	}
-
-	# The above are standard suffixes; deal with single alphabetical
-	# suffixes too, e.g. 1.0.1h
-	if ($a =~ s/([a-zA-Z]){1}$//) {
-	    say_debug("valid suffix $1 found in $a$1.");
-	    $suffix_a[0] = $1;
-	}
-
-	if ($b =~ s/([a-zA-Z]){1}$//) {
-	    say_debug("valid suffix $1 found in $b$1.");
-	    $suffix_b[0] = $1;
+	if ($b =~ $vers_regexp && ($3 || $4)) {
+		$b = $1;
+		say_debug("valid suffix $3$4 found in $b$3$4");
+		$suffix_b[0] = $3;
+		$suffix_b[0] =~ s/^-//;
+		$suffix_b[1] = $4 || 0;
 	}
 
 	my @a = split(/\./, $a);


### PR DESCRIPTION
1) Fix the libevent warning by switching to a regular expression that accommodates that case
2) Put this regexp in a variable and use it everywhere (main loop and compare())
3) Move --errors-to-stdout code to early in main program

Thanks for working with me on this.
